### PR TITLE
chore(DVE-4): gitignore .claude/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /target
+
+# AI tooling (local only)
+.claude/


### PR DESCRIPTION
## Summary
- Add `.claude/` to `.gitignore` — AI tooling stays local

Closes #4